### PR TITLE
openssf-scorecard: Add token input for gh CLI authentication

### DIFF
--- a/openssf-scorecard/action.yml
+++ b/openssf-scorecard/action.yml
@@ -26,12 +26,18 @@ inputs:
   head-sha:
     description: 'Head commit SHA'
     required: true
+  token:
+    description: 'GitHub token for API access (e.g., downloading scorecard)'
+    default: ${{ github.token }}
+    required: false
 
 runs:
   using: 'composite'
   steps:
     - name: Install scorecard
       shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
       run: |
         set -euo pipefail
         # renovate: datasource=github-releases depName=ossf/scorecard


### PR DESCRIPTION
The gh CLI requires GH_TOKEN to be set when running in GitHub Actions. Add an optional 'token' input that defaults to github.token, following the common pattern used by official GitHub actions.

This allows callers to override with a PAT if needed (e.g., for cross-repo access) while working automatically in the common case.

Assisted-by: OpenCode (claude-sonnet-4-20250514)