### PR TITLE
scorecard: Update to v5.4.0

### DIFF
--- a/openssf-scorecard/action.yml
+++ b/openssf-scorecard/action.yml
@@ -41,7 +41,7 @@ runs:
       run: |
         set -euo pipefail
         # renovate: datasource=github-releases depName=ossf/scorecard
-        VERSION=v5.1.1
+        VERSION=v5.4.0
         ARCH=$(uname -m | sed 's/x86_64/amd64/')
         TARBALL="scorecard_${VERSION#v}_linux_${ARCH}.tar.gz"
         


### PR DESCRIPTION
Since v5.3.0, scorecard skips dangling symlinks and detects symlink path traversal when run on local files

That resolved bootc repo error:
`Error: check runtime error: Binary-Artifacts: internal error: error during ListFiles: error walking the path ".": stat baseimage/base/ostree: no such file or directory`

https://github.com/bootc-dev/bootc/actions/runs/21049699430/job/60560609756?pr=1920
