### PR TITLE
bootc-ubuntu-setup: Use correct apt mirror for arm64

### DIFF
--- a/.github/actions/bootc-ubuntu-setup/action.yml
+++ b/.github/actions/bootc-ubuntu-setup/action.yml
@@ -47,7 +47,22 @@ runs:
         IDV=$(. /usr/lib/os-release && echo ${ID}-${VERSION_ID})
         test "${IDV}" = "ubuntu-24.04"
         # plucky is the next release
-        echo 'deb http://azure.archive.ubuntu.com/ubuntu plucky universe main' | sudo tee /etc/apt/sources.list.d/plucky.list
+        # Ubuntu uses different mirrors for different architectures:
+        # - amd64: azure.archive.ubuntu.com/ubuntu (on Azure runners)
+        # - arm64: ports.ubuntu.com/ubuntu-ports
+        case "$(arch)" in
+          x86_64)
+            mirror="http://azure.archive.ubuntu.com/ubuntu"
+            ;;
+          aarch64)
+            mirror="http://ports.ubuntu.com/ubuntu-ports"
+            ;;
+          *)
+            echo "Unsupported architecture: $(arch)" >&2
+            exit 1
+            ;;
+        esac
+        echo "deb ${mirror} plucky universe main" | sudo tee /etc/apt/sources.list.d/plucky.list
         /bin/time -f '%E %C' sudo apt update
         # skopeo is currently older in plucky for some reason hence --allow-downgrades
         /bin/time -f '%E %C' sudo apt install -y --allow-downgrades crun/plucky podman/plucky skopeo/plucky just


### PR DESCRIPTION
## Summary

- Fix arm64 apt update failure by using the correct Ubuntu mirror (`ports.ubuntu.com/ubuntu-ports`) instead of `azure.archive.ubuntu.com` which only hosts amd64 packages

## Problem

On arm64 GitHub runners (`ubuntu-24.04-arm`), the `apt update` step fails with:
```
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/dists/plucky/universe/binary-arm64/Packages  404  Not Found
```

This is because `azure.archive.ubuntu.com` only mirrors x86_64/amd64 packages. Ubuntu uses `ports.ubuntu.com/ubuntu-ports` for arm64.

## Fix

Detect the architecture using `$(arch)` and select the appropriate mirror:
- `x86_64` → `azure.archive.ubuntu.com/ubuntu`
- `aarch64` → `ports.ubuntu.com/ubuntu-ports`

Fixes: https://github.com/cgwalters/service-gator/actions/runs/21484445531