### PR TITLE
bootc-ubuntu-setup: Handle arm64 runners too

### DIFF
--- a/.github/actions/bootc-ubuntu-setup/action.yml
+++ b/.github/actions/bootc-ubuntu-setup/action.yml
@@ -47,7 +47,22 @@ runs:
         IDV=$(. /usr/lib/os-release && echo ${ID}-${VERSION_ID})
         test "${IDV}" = "ubuntu-24.04"
         # plucky is the next release
-        echo 'deb http://azure.archive.ubuntu.com/ubuntu plucky universe main' | sudo tee /etc/apt/sources.list.d/plucky.list
+        # Ubuntu uses different mirrors for different architectures:
+        # - amd64: azure.archive.ubuntu.com/ubuntu (on Azure runners)
+        # - arm64: ports.ubuntu.com/ubuntu-ports
+        case "$(arch)" in
+          x86_64)
+            mirror="http://azure.archive.ubuntu.com/ubuntu"
+            ;;
+          aarch64)
+            mirror="http://ports.ubuntu.com/ubuntu-ports"
+            ;;
+          *)
+            echo "Unsupported architecture: $(arch)" >&2
+            exit 1
+            ;;
+        esac
+        echo "deb ${mirror} plucky universe main" | sudo tee /etc/apt/sources.list.d/plucky.list
         /bin/time -f '%E %C' sudo apt update
         # skopeo is currently older in plucky for some reason hence --allow-downgrades
         /bin/time -f '%E %C' sudo apt install -y --allow-downgrades crun/plucky podman/plucky skopeo/plucky just


### PR DESCRIPTION
Obviously messy and we should be building our own runner images.

Assisted-by: OpenCode (Opus 4.5)