### PR TITLE
bootc-ubuntu-setup: Deal with missing /dev/kvm on arm64

### DIFF
--- a/.github/actions/bootc-ubuntu-setup/action.yml
+++ b/.github/actions/bootc-ubuntu-setup/action.yml
@@ -73,8 +73,13 @@ runs:
         set -xeuo pipefail
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
         sudo udevadm control --reload-rules
-        sudo udevadm trigger --name-match=kvm
-        ls -l /dev/kvm
+        # Only trigger if /dev/kvm exists (may not be available on arm64 runners)
+        if [ -e /dev/kvm ]; then
+          sudo udevadm trigger --name-match=kvm
+          ls -l /dev/kvm
+        else
+          echo "Note: /dev/kvm not available on this runner"
+        fi
     # Used by a few workflows, but generally useful
     - name: Set architecture variable
       id: set_arch


### PR DESCRIPTION
Tested via: https://github.com/bootc-dev/ci-sandbox/actions/runs/21491385143

Assisted-by: OpenCode (Claude claude-opus-4-5)