### PR TITLE
bootc-ubuntu-setup: Use ports.ubuntu.com for arm64 plucky apt source

### DIFF
--- a/.github/actions/bootc-ubuntu-setup/action.yml
+++ b/.github/actions/bootc-ubuntu-setup/action.yml
@@ -46,8 +46,14 @@ runs:
         # Require the runner is ubuntu-24.04
         IDV=$(. /usr/lib/os-release && echo ${ID}-${VERSION_ID})
         test "${IDV}" = "ubuntu-24.04"
-        # plucky is the next release
-        echo 'deb http://azure.archive.ubuntu.com/ubuntu plucky universe main' | sudo tee /etc/apt/sources.list.d/plucky.list
+        # plucky is the next release. The azure.archive.ubuntu.com mirror only carries amd64.
+        # Other architectures like arm64 use ports.ubuntu.com/ubuntu-ports.
+        if [ "$(dpkg --print-architecture)" = "amd64" ]; then
+          mirror="http://azure.archive.ubuntu.com/ubuntu"
+        else
+          mirror="http://ports.ubuntu.com/ubuntu-ports"
+        fi
+        echo "deb ${mirror} plucky universe main" | sudo tee /etc/apt/sources.list.d/plucky.list
         /bin/time -f '%E %C' sudo apt update
         # skopeo is currently older in plucky for some reason hence --allow-downgrades
         /bin/time -f '%E %C' sudo apt install -y --allow-downgrades crun/plucky podman/plucky skopeo/plucky just


### PR DESCRIPTION
The azure.archive.ubuntu.com mirror only carries amd64 packages. On arm64 runners, apt update fails with a 404 when trying to fetch binary-arm64/Packages from that mirror. Use ports.ubuntu.com/ubuntu-ports for arm64 instead, which is the canonical Ubuntu archive for non-amd64 architectures.

Fixes: https://github.com/cgwalters/devaipod/actions/runs/22802682435/job/66147135926

Assisted-by: OpenCode (Claude claude-opus-4-6)