### PR TITLE
discover-repos: Remove template expressions from input description

### DIFF
--- a/discover-repos/action.yml
+++ b/discover-repos/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: 'JSON array of organizations to scan, e.g. ["bootc-dev", "composefs"]'
     required: true
   tokens:
-    description: 'JSON object mapping org names to tokens, e.g. {"bootc-dev": "${{ token1 }}", "composefs": "${{ token2 }}"}'
+    description: 'JSON object mapping org names to tokens, e.g. {"bootc-dev": "TOKEN1", "composefs": "TOKEN2"}'
     required: true
   test-mode:
     description: 'When true, only return ci-sandbox from the first org'


### PR DESCRIPTION
The tokens input description contained literal ${{ }} template expression examples, which caused the GitHub Actions runner to fail parsing the action.yml with "A template expression is not allowed in this context".

Replace the example template expressions with plain-text placeholders.

Assisted-by: OpenCode (Claude claude-opus-4-6)