### PR TITLE
bootc-ubuntu-setup: Replace symlink with actual file

### DIFF
--- a/.github/workflows/test-actions-pr.yml
+++ b/.github/workflows/test-actions-pr.yml
@@ -1,0 +1,56 @@
+name: Test actions (PR)
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test-bootc-ubuntu-setup:
+    name: Test bootc-ubuntu-setup
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run bootc-ubuntu-setup
+        uses: ./bootc-ubuntu-setup
+
+      - name: Verify setup
+        run: |
+          podman --version
+          just --version
+          test -n "$ARCH"
+
+  test-setup-rust:
+    name: Test setup-rust
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run setup-rust
+        uses: ./setup-rust
+
+      - name: Verify setup
+        run: |
+          rustc --version
+          cargo --version
+          cargo nextest --version
+
+  test-openssf-scorecard:
+    name: Test openssf-scorecard
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run openssf-scorecard
+        uses: ./openssf-scorecard
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-sha: ${{ github.sha }}

--- a/.github/workflows/test-actions-published.yml
+++ b/.github/workflows/test-actions-published.yml
@@ -1,0 +1,50 @@
+name: Test published actions
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test-bootc-ubuntu-setup:
+    name: Test bootc-ubuntu-setup@main
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Run bootc-ubuntu-setup
+        uses: bootc-dev/actions/bootc-ubuntu-setup@main
+
+      - name: Verify setup
+        run: |
+          podman --version
+          just --version
+          test -n "$ARCH"
+
+  test-setup-rust:
+    name: Test setup-rust@main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run setup-rust
+        uses: bootc-dev/actions/setup-rust@main
+
+      - name: Verify setup
+        run: |
+          rustc --version
+          cargo --version
+          cargo nextest --version
+
+  test-openssf-scorecard:
+    name: Test openssf-scorecard@main
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run openssf-scorecard
+        uses: bootc-dev/actions/openssf-scorecard@main
+        with:
+          base-sha: ${{ github.event.before }}
+          head-sha: ${{ github.sha }}

--- a/bootc-ubuntu-setup/action.yml
+++ b/bootc-ubuntu-setup/action.yml
@@ -1,1 +1,105 @@
-../.github/actions/bootc-ubuntu-setup/action.yml
+name: 'Bootc Ubuntu Setup'
+description: 'Default host setup'
+inputs:
+  libvirt:
+    description: 'Install libvirt and virtualization stack'
+    required: false
+    default: 'false'
+runs:
+  using: 'composite'
+  steps:
+    # The default runners have TONS of crud on them...
+    - name: Free up disk space on runner
+      shell: bash
+      run: |
+        set -xeuo pipefail
+        sudo df -h
+        # Use globs for package patterns (apt and dpkg both support fnmatch globs)
+        unwanted_pkgs=('aspnetcore-*' 'dotnet-*' 'llvm-*' 'php*' 'mongodb-*' 'mysql-*'
+                       azure-cli google-chrome-stable firefox mono-devel)
+        unwanted_dirs=(/usr/share/dotnet /opt/ghc /usr/local/lib/android /opt/hostedtoolcache/CodeQL)
+        # Start background removal operations as systemd units; if this causes
+        # races in the future around disk space we can look at waiting for cleanup
+        # before starting further jobs, but right now we spent a lot of time waiting
+        # on the network and scripts and such below, giving these plenty of time to run.
+        n=0
+        runcleanup() {
+          sudo systemd-run -r -u action-cleanup-${n} -- "$@"
+          n=$(($n + 1))
+        }
+        runcleanup docker image prune --all --force
+        for x in ${unwanted_dirs[@]}; do
+          runcleanup rm -rf "$x"
+        done
+        # Apt removals in foreground, as we can't parallelize these.
+        # Only attempt removal if matching packages are installed.
+        for x in ${unwanted_pkgs[@]}; do
+          if dpkg -l "$x" >/dev/null 2>&1; then
+            /bin/time -f '%E %C' sudo apt-get remove -y "$x"
+          fi
+        done
+    # We really want support for heredocs
+    - name: Update podman and install just
+      shell: bash
+      run: |
+        set -eux
+        # Require the runner is ubuntu-24.04
+        IDV=$(. /usr/lib/os-release && echo ${ID}-${VERSION_ID})
+        test "${IDV}" = "ubuntu-24.04"
+        # plucky is the next release. The azure.archive.ubuntu.com mirror only carries amd64.
+        # Other architectures like arm64 use ports.ubuntu.com/ubuntu-ports.
+        if [ "$(dpkg --print-architecture)" = "amd64" ]; then
+          mirror="http://azure.archive.ubuntu.com/ubuntu"
+        else
+          mirror="http://ports.ubuntu.com/ubuntu-ports"
+        fi
+        echo "deb ${mirror} plucky universe main" | sudo tee /etc/apt/sources.list.d/plucky.list
+        /bin/time -f '%E %C' sudo apt update
+        # skopeo is currently older in plucky for some reason hence --allow-downgrades
+        /bin/time -f '%E %C' sudo apt install -y --allow-downgrades crun/plucky podman/plucky skopeo/plucky just
+    # This is the default on e.g. Fedora derivatives, but not Debian.
+    # Only needed when libvirt/virtualization is requested.
+    - name: Enable unprivileged /dev/kvm access
+      if: ${{ inputs.libvirt == 'true' }}
+      shell: bash
+      run: |
+        set -xeuo pipefail
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+        ls -l /dev/kvm
+    # Used by a few workflows, but generally useful
+    - name: Set architecture variable
+      id: set_arch
+      shell: bash
+      run: echo "ARCH=$(arch)" >> $GITHUB_ENV
+    # Install libvirt stack if requested
+    - name: Install libvirt and virtualization stack
+      if: ${{ inputs.libvirt == 'true' }}
+      shell: bash
+      run: |
+        set -xeuo pipefail
+        # renovate: datasource=github-releases depName=bootc-dev/bcvk
+        export BCVK_VERSION=0.11.0
+        # see https://github.com/bootc-dev/bcvk/issues/176
+        /bin/time -f '%E %C' sudo apt install -y libkrb5-dev pkg-config libvirt-dev genisoimage qemu-utils qemu-kvm virtiofsd libvirt-daemon-system python3-virt-firmware
+        # Something in the stack is overriding this, but we want session right now for bcvk
+        echo LIBVIRT_DEFAULT_URI=qemu:///session >> $GITHUB_ENV
+        td=$(mktemp -d)
+        cd $td
+        # Install bcvk
+        target=bcvk-$(arch)-unknown-linux-gnu
+        /bin/time -f '%E %C' curl -LO https://github.com/bootc-dev/bcvk/releases/download/v${BCVK_VERSION}/${target}.tar.gz
+        tar xzf ${target}.tar.gz
+        sudo install -T ${target} /usr/bin/bcvk
+        cd -
+        rm -rf "$td"
+
+        # Also bump the default fd limit as a workaround for https://github.com/bootc-dev/bcvk/issues/65
+        sudo sed -i -e 's,^\* hard nofile 65536,* hard nofile 524288,' /etc/security/limits.conf
+    - name: Cleanup status
+      shell: bash
+      run: |
+        set -xeuo pipefail
+        systemctl list-units 'action-cleanup*'
+        df -h


### PR DESCRIPTION
The symlink to .github/actions/bootc-ubuntu-setup/action.yml was broken after the infra sync (PR #25) correctly removed .github/actions/ from this repo. The actions now live canonically here, so replace the symlink with the actual file content.

I approved and merged PR #25 and import this broken issue. I thought the `action.yml` was in bootc-ubuntu-setup folder, but not. So my fault.

To avoid this kind of issue, I added test for all actions.