### PR TITLE
build-push-image, create-manifest: Add multiarch container build actions

### DIFF
--- a/.github/workflows/test-actions-pr.yml
+++ b/.github/workflows/test-actions-pr.yml
@@ -54,3 +54,79 @@ jobs:
         with:
           base-sha: ${{ github.event.pull_request.base.sha }}
           head-sha: ${{ github.sha }}
+
+  test-build-push-image:
+    name: Test build-push-image (build only)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup host
+        uses: ./bootc-ubuntu-setup
+
+      - name: Create test Containerfile
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/test-ctx
+          echo 'FROM docker.io/library/alpine:latest' > /tmp/test-ctx/Containerfile
+          echo 'RUN echo hello > /hello.txt' >> /tmp/test-ctx/Containerfile
+
+      - name: Run build-push-image (push=false)
+        id: build
+        uses: ./build-push-image
+        with:
+          image: ghcr.io/bootc-dev/actions-test
+          arch: amd64
+          containerfile: /tmp/test-ctx/Containerfile
+          context: /tmp/test-ctx
+          push: 'false'
+
+      - name: Verify image was built
+        shell: bash
+        env:
+          LOCAL_IMAGE: ${{ steps.build.outputs.local-image }}
+        run: |
+          set -euo pipefail
+          test -n "${LOCAL_IMAGE}"
+          podman inspect "${LOCAL_IMAGE}"
+          result="$(podman run --rm "${LOCAL_IMAGE}" cat /hello.txt)"
+          test "${result}" = "hello"
+
+  test-build-push-image-local:
+    name: Test build-push-image with local-image
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup host
+        uses: ./bootc-ubuntu-setup
+
+      - name: Build image manually
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo 'FROM docker.io/library/alpine:latest' > /tmp/Containerfile
+          echo 'RUN echo custom > /custom.txt' >> /tmp/Containerfile
+          podman build -t localhost/my-custom-image:latest -f /tmp/Containerfile /tmp
+
+      - name: Run build-push-image with pre-built image (push=false)
+        id: build
+        uses: ./build-push-image
+        with:
+          image: ghcr.io/bootc-dev/actions-test
+          arch: amd64
+          local-image: localhost/my-custom-image:latest
+          push: 'false'
+
+      - name: Verify correct image was used
+        shell: bash
+        env:
+          LOCAL_IMAGE: ${{ steps.build.outputs.local-image }}
+        run: |
+          set -euo pipefail
+          test "${LOCAL_IMAGE}" = "localhost/my-custom-image:latest"
+          result="$(podman run --rm "${LOCAL_IMAGE}" cat /custom.txt)"
+          test "${result}" = "custom"

--- a/.github/workflows/test-container-integration.yml
+++ b/.github/workflows/test-container-integration.yml
@@ -1,0 +1,100 @@
+# End-to-end integration test for build-push-image + create-manifest.
+#
+# This workflow pushes real container images to GHCR, so it requires
+# packages:write.  It is gated behind a label or manual dispatch to
+# avoid granting elevated permissions on every PR or push.
+#
+# OpenSSF Scorecard note: packages:write is intentionally scoped to
+# this workflow only, and the workflow only runs when explicitly
+# requested via label or workflow_dispatch.  The push and manifest
+# jobs need write access to verify the full build-push-manifest
+# pipeline against a real registry.
+name: Test container build (integration)
+on:
+  pull_request:
+    types: [labeled, synchronize]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  # Build on two arches and push by digest
+  build:
+    name: Build (${{ matrix.arch }})
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'test-integration')
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup host
+        uses: ./bootc-ubuntu-setup
+
+      - name: Create test Containerfile
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/test-ctx
+          echo 'FROM docker.io/library/alpine:latest' > /tmp/test-ctx/Containerfile
+          echo 'RUN echo hello > /hello.txt' >> /tmp/test-ctx/Containerfile
+
+      - name: Build and push
+        uses: ./build-push-image
+        with:
+          image: ghcr.io/${{ github.repository }}/integration-test
+          arch: ${{ matrix.arch }}
+          containerfile: /tmp/test-ctx/Containerfile
+          context: /tmp/test-ctx
+
+  # Assemble multi-arch manifest and verify
+  manifest:
+    name: Create manifest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+      id-token: write  # for cosign signing
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup host
+        uses: ./bootc-ubuntu-setup
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/integration-test
+          tags: |
+            type=raw,value=latest
+            type=sha,format=short
+
+      - name: Create and push manifest
+        uses: ./create-manifest
+        with:
+          image: ghcr.io/${{ github.repository }}/integration-test
+          tags: ${{ steps.meta.outputs.tags }}
+
+      - name: Verify manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          podman manifest inspect ghcr.io/${{ github.repository }}/integration-test:latest
+          arch_count=$(podman manifest inspect ghcr.io/${{ github.repository }}/integration-test:latest | jq '.manifests | length')
+          test "${arch_count}" -eq 2

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -1,0 +1,179 @@
+# Build a container image for a single architecture and push by digest to a
+# registry.  Designed to run inside a matrix strategy that fans out over
+# architectures; a companion `create-manifest` action assembles the per-arch
+# images into a multi-arch manifest list afterwards.
+#
+# Prerequisites:
+#   Use bootc-dev/actions/bootc-ubuntu-setup first to get an up-to-date
+#   podman.  The version shipped with ubuntu-24.04 is too old and has
+#   known bugs with manifest handling and push-by-digest.
+#
+# The runner's native architecture must match the `arch` input — this action
+# does not do cross-compilation.  Use a matrix like:
+#
+#   strategy:
+#     matrix:
+#       arch: [amd64, arm64]
+#       include:
+#         - arch: amd64
+#           runner: ubuntu-24.04
+#         - arch: arm64
+#           runner: ubuntu-24.04-arm
+#   runs-on: ${{ matrix.runner }}
+#   steps:
+#     - uses: actions/checkout@v6
+#     - uses: bootc-dev/actions/bootc-ubuntu-setup@main
+#     - uses: bootc-dev/actions/build-push-image@main
+#       with:
+#         image: ghcr.io/${{ github.repository }}
+#         arch: ${{ matrix.arch }}
+#
+name: 'Build and Push Image'
+description: 'Build a container image for one architecture and push it by digest'
+inputs:
+  image:
+    description: 'Full registry image name without tag (e.g. ghcr.io/org/repo)'
+    required: true
+  arch:
+    description: >
+      Architecture label for this build (e.g. amd64, arm64).  Used for artifact
+      naming and manifest assembly — the runner must be the matching native arch.
+    required: true
+  containerfile:
+    description: 'Path to the Containerfile/Dockerfile'
+    required: false
+    default: './Containerfile'
+  context:
+    description: 'Build context directory'
+    required: false
+    default: '.'
+  build-args:
+    description: 'Newline-separated list of --build-arg values'
+    required: false
+    default: ''
+  local-image:
+    description: >
+      Reference to a pre-built local image to push instead of building.
+      When set, the build step is skipped entirely.  Useful when the caller
+      has a custom build process (e.g. `just container-build`).
+    required: false
+    default: ''
+  push:
+    description: 'Whether to push the image (set false for PR builds)'
+    required: false
+    default: 'true'
+  registry-login-env:
+    description: >
+      Set to "true" if you have already logged in to the registry.
+      Otherwise the action will attempt to log in using GITHUB_TOKEN.
+    required: false
+    default: 'false'
+  max-retries:
+    description: 'Number of push retries on transient failure'
+    required: false
+    default: '3'
+outputs:
+  digest:
+    description: 'The pushed image digest (sha256:...)'
+    value: ${{ steps.push.outputs.digest }}
+  local-image:
+    description: 'The local image reference that was built (or passed through)'
+    value: ${{ steps.build.outputs.local-image }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Login to GHCR
+      if: inputs.push == 'true' && inputs.registry-login-env == 'false'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        LOGIN_USER: ${{ github.actor }}
+        REGISTRY: ${{ inputs.image }}
+      run: |
+        set -euo pipefail
+        registry_host="${REGISTRY%%/*}"
+        echo "${GITHUB_TOKEN}" | podman login -u "${LOGIN_USER}" --password-stdin "${registry_host}"
+
+    - name: Build image
+      id: build
+      uses: actions/github-script@v7
+      env:
+        IMAGE: ${{ inputs.image }}
+        CONTAINERFILE: ${{ inputs.containerfile }}
+        CONTEXT: ${{ inputs.context }}
+        BUILD_ARGS: ${{ inputs.build-args }}
+        LOCAL_IMAGE_INPUT: ${{ inputs.local-image }}
+      with:
+        script: |
+          const { execFileSync } = require('child_process');
+
+          // If caller provided a pre-built image, just pass it through
+          if (process.env.LOCAL_IMAGE_INPUT) {
+            core.setOutput('local-image', process.env.LOCAL_IMAGE_INPUT);
+            core.info(`Using pre-built image: ${process.env.LOCAL_IMAGE_INPUT}`);
+            return;
+          }
+
+          const image = process.env.IMAGE;
+          const basename = image.split('/').pop();
+          const localImage = `localhost/${basename}:latest`;
+
+          const args = ['build', '-t', localImage, '-f', process.env.CONTAINERFILE];
+          for (const line of process.env.BUILD_ARGS.split('\n')) {
+            const arg = line.trim();
+            if (arg) args.push('--build-arg', arg);
+          }
+          args.push(process.env.CONTEXT);
+
+          core.info(`Running: podman ${args.join(' ')}`);
+          execFileSync('podman', args, { stdio: 'inherit' });
+
+          core.setOutput('local-image', localImage);
+
+    - name: Push by digest
+      id: push
+      if: inputs.push == 'true'
+      uses: actions/github-script@v7
+      env:
+        IMAGE: ${{ inputs.image }}
+        LOCAL_IMAGE: ${{ steps.build.outputs.local-image }}
+        ARCH: ${{ inputs.arch }}
+        MAX_RETRIES: ${{ inputs.max-retries }}
+        RUNNER_TEMP: ${{ runner.temp }}
+      with:
+        script: |
+          const { execFileSync } = require('child_process');
+          const fs = require('fs');
+          const path = require('path');
+
+          const image = process.env.IMAGE;
+          const localImage = process.env.LOCAL_IMAGE;
+          const arch = process.env.ARCH;
+          const maxRetries = process.env.MAX_RETRIES;
+
+          execFileSync('podman', ['tag', localImage, `${image}:latest`], { stdio: 'inherit' });
+
+          const digestfile = path.join(process.env.RUNNER_TEMP, 'push-digestfile');
+          execFileSync('podman', [
+            'push', '--retry', maxRetries, '--digestfile', digestfile, `${image}:latest`
+          ], { stdio: 'inherit' });
+
+          const digest = fs.readFileSync(digestfile, 'utf8').trim();
+
+          // Write digest artifact for create-manifest; filename encodes
+          // the arch so the manifest job can associate digests with platforms.
+          const artifactDir = path.join(process.env.RUNNER_TEMP, 'build-push-image', 'digests');
+          fs.mkdirSync(artifactDir, { recursive: true });
+          fs.writeFileSync(path.join(artifactDir, arch), digest);
+
+          core.info(`Pushed ${image}@${digest} (${arch})`);
+          core.setOutput('digest', digest);
+
+    - name: Upload digest artifact
+      if: inputs.push == 'true'
+      uses: actions/upload-artifact@v7
+      with:
+        name: container-digests-${{ inputs.arch }}
+        path: ${{ runner.temp }}/build-push-image/digests/*
+        if-no-files-found: error
+        retention-days: 1

--- a/create-manifest/action.yml
+++ b/create-manifest/action.yml
@@ -1,0 +1,183 @@
+# Assemble per-architecture images (pushed by build-push-image) into a
+# multi-arch manifest list and push it with the desired tags.
+#
+# Prerequisites:
+#   Use bootc-dev/actions/bootc-ubuntu-setup first to get an up-to-date
+#   podman.  The version shipped with ubuntu-24.04 is too old and has
+#   known bugs with manifest handling.
+#
+# This action downloads the digest artifacts produced by build-push-image,
+# creates a podman manifest with correct per-arch metadata, and pushes it
+# for each tag derived from docker/metadata-action (or supplied manually).
+#
+# Typical usage (runs after a matrix of build-push-image jobs):
+#
+#   manifest:
+#     needs: build
+#     runs-on: ubuntu-24.04
+#     steps:
+#       - uses: bootc-dev/actions/bootc-ubuntu-setup@main
+#       - uses: docker/metadata-action@v5
+#         id: meta
+#         with:
+#           images: ghcr.io/${{ github.repository }}
+#           tags: |
+#             type=raw,value=latest,enable={{is_default_branch}}
+#             type=sha,prefix={{branch}}-,format=short
+#       - uses: bootc-dev/actions/create-manifest@main
+#         with:
+#           image: ghcr.io/${{ github.repository }}
+#           tags: ${{ steps.meta.outputs.tags }}
+#
+name: 'Create Multi-Arch Manifest'
+description: 'Assemble per-arch images into a multi-arch manifest and push'
+inputs:
+  image:
+    description: 'Full registry image name without tag (must match build-push-image)'
+    required: true
+  tags:
+    description: >
+      Newline-separated list of fully qualified image tags to push
+      (e.g. output of docker/metadata-action).
+    required: true
+  labels:
+    description: >
+      Newline-separated list of OCI annotations to apply to the manifest index
+      (e.g. output of docker/metadata-action labels).  Format: key=value.
+    required: false
+    default: ''
+  artifact-pattern:
+    description: 'Download artifact name pattern (must match build-push-image output)'
+    required: false
+    default: 'container-digests-*'
+  cosign-key:
+    description: 'Cosign private key for signing (leave empty to skip signing)'
+    required: false
+    default: ''
+  cosign-password:
+    description: 'Password for the cosign private key (if encrypted)'
+    required: false
+    default: ''
+  registry-login-env:
+    description: >
+      Set to "true" if you have already logged in to the registry.
+      Otherwise the action will attempt to log in using GITHUB_TOKEN.
+    required: false
+    default: 'false'
+outputs:
+  digest:
+    description: 'Digest of the pushed manifest'
+    value: ${{ steps.push-manifest.outputs.digest }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Download digest artifacts
+      uses: actions/download-artifact@v8
+      with:
+        path: ${{ runner.temp }}/digests
+        pattern: ${{ inputs.artifact-pattern }}
+        merge-multiple: true
+
+    - name: Login to GHCR
+      if: inputs.registry-login-env == 'false'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        LOGIN_USER: ${{ github.actor }}
+        REGISTRY: ${{ inputs.image }}
+      run: |
+        set -euo pipefail
+        registry_host="${REGISTRY%%/*}"
+        echo "${GITHUB_TOKEN}" | podman login -u "${LOGIN_USER}" --password-stdin "${registry_host}"
+        # Cosign uses the Docker credential store for pushing signatures
+        echo "${GITHUB_TOKEN}" | docker login -u "${LOGIN_USER}" --password-stdin "${registry_host}"
+
+    - name: Create and push manifest
+      id: push-manifest
+      uses: actions/github-script@v7
+      env:
+        IMAGE: ${{ inputs.image }}
+        TAGS: ${{ inputs.tags }}
+        LABELS: ${{ inputs.labels }}
+        DIGEST_DIR: ${{ runner.temp }}/digests
+        RUNNER_TEMP: ${{ runner.temp }}
+      with:
+        script: |
+          const { execFileSync } = require('child_process');
+          const fs = require('fs');
+          const path = require('path');
+
+          const image = process.env.IMAGE;
+          const digestDir = process.env.DIGEST_DIR;
+
+          // Read per-arch digest files (each named by arch, containing the digest)
+          const entries = fs.readdirSync(digestDir)
+            .filter(f => fs.statSync(path.join(digestDir, f)).isFile())
+            .map(arch => ({
+              arch,
+              digest: fs.readFileSync(path.join(digestDir, arch), 'utf8').trim()
+            }));
+
+          if (entries.length === 0) {
+            core.setFailed(`No digest artifacts found in ${digestDir}`);
+            return;
+          }
+          core.info(`Found ${entries.length} architecture(s): ${entries.map(e => e.arch).join(', ')}`);
+
+          const tags = process.env.TAGS.split('\n').map(t => t.trim()).filter(Boolean);
+          const labels = process.env.LABELS.split('\n').map(l => l.trim()).filter(Boolean);
+
+          const digestfile = path.join(process.env.RUNNER_TEMP, 'manifest-digestfile');
+          const manifestName = `localhost/manifest-tmp:${Date.now()}`;
+
+          // Build the manifest once, then push to each tag
+          core.info(`Creating manifest: ${manifestName}`);
+          execFileSync('podman', ['manifest', 'create', manifestName], { stdio: 'inherit' });
+
+          let lastDigest = '';
+          try {
+            for (const { arch, digest } of entries) {
+              core.info(`  Adding ${arch}: ${digest}`);
+              execFileSync('podman', [
+                'manifest', 'add', '--arch', arch, manifestName, `${image}@${digest}`
+              ], { stdio: 'inherit' });
+            }
+
+            for (const label of labels) {
+              execFileSync('podman', [
+                'manifest', 'annotate', '--index', '--annotation', label, manifestName
+              ], { stdio: 'inherit' });
+            }
+
+            for (const tag of tags) {
+              core.info(`Pushing manifest as ${tag}`);
+              execFileSync('podman', [
+                'manifest', 'push', '--all', '--digestfile', digestfile, manifestName, tag
+              ], { stdio: 'inherit' });
+              lastDigest = fs.readFileSync(digestfile, 'utf8').trim();
+            }
+          } finally {
+            execFileSync('podman', ['manifest', 'rm', manifestName], { stdio: 'inherit' });
+          }
+
+          if (!lastDigest) {
+            core.setFailed('Failed to determine manifest digest');
+            return;
+          }
+          core.setOutput('digest', lastDigest);
+
+    - name: Install Cosign
+      if: inputs.cosign-key != ''
+      uses: sigstore/cosign-installer@v3
+
+    - name: Sign manifest
+      if: inputs.cosign-key != ''
+      shell: bash
+      env:
+        COSIGN_PRIVATE_KEY: ${{ inputs.cosign-key }}
+        COSIGN_PASSWORD: ${{ inputs.cosign-password }}
+        IMAGE: ${{ inputs.image }}
+        DIGEST: ${{ steps.push-manifest.outputs.digest }}
+      run: |
+        set -euo pipefail
+        cosign sign -y --key env://COSIGN_PRIVATE_KEY "${IMAGE}@${DIGEST}"


### PR DESCRIPTION
So the bootcrew folks (I think inherited from ublue?) had some decent code to do multiarch (x86_64 + aarch64) container builds using the public GHA native runners.

Pull that in, clean it up (IMO bash is too hacky for parsing, so some of that stuff became JS) and make them cleanly reusable actions.

Assisted-by: OpenCode (claude-opus-4-6)