### PR TITLE
bootc-ubuntu-setup: Raise apt retry count and add curl retries

### DIFF
--- a/bootc-ubuntu-setup/action.yml
+++ b/bootc-ubuntu-setup/action.yml
@@ -54,6 +54,9 @@ runs:
           mirror="http://ports.ubuntu.com/ubuntu-ports"
         fi
         echo "deb ${mirror} plucky universe main" | sudo tee /etc/apt/sources.list.d/plucky.list
+        # apt has a compiled-in default of 3 retries with exponential backoff (1s, 2s, 4s),
+        # capped at 30s per attempt. 34 retries covers ~15 min of cumulative delay; use 35.
+        echo 'Acquire::Retries "35";' | sudo tee /etc/apt/apt.conf.d/80-retries
         /bin/time -f '%E %C' sudo apt update
         # skopeo is currently older in plucky for some reason hence --allow-downgrades
         /bin/time -f '%E %C' sudo apt install -y --allow-downgrades crun/plucky buildah/plucky podman/plucky skopeo/plucky just
@@ -89,7 +92,7 @@ runs:
         cd $td
         # Install bcvk
         target=bcvk-$(arch)-unknown-linux-gnu
-        /bin/time -f '%E %C' curl -LO https://github.com/bootc-dev/bcvk/releases/download/v${BCVK_VERSION}/${target}.tar.gz
+        /bin/time -f '%E %C' curl --retry 35 --retry-delay 30 --retry-max-time 1200 -LO https://github.com/bootc-dev/bcvk/releases/download/v${BCVK_VERSION}/${target}.tar.gz
         tar xzf ${target}.tar.gz
         sudo install -T ${target} /usr/bin/bcvk
         cd -


### PR DESCRIPTION
Increase apt's retry to have a *much* longer timeout, and add one in our raw curl invocation.

Seen in e.g. https://github.com/bootc-dev/bootc/actions/runs/25390326567/job/74467653101

Assisted-by: OpenCode (claude-sonnet-4-6@default)